### PR TITLE
Fix broken downloads URL

### DIFF
--- a/README
+++ b/README
@@ -2,7 +2,7 @@ Geppetto is aimed at developing tools to simplify the process of authoring and
 consuming Puppet modules and manifests.
 
 The Geppetto IDE tooling can be downloaded as a stand-alone product
-from https://downloads.puppetlabs.com/geppetto/downloads
+from https://puppetlabs.github.io/geppetto/download.html
 or installed into an existing Eclipse IDE from
 http://updates.puppetlabs.com/geppetto.
 


### PR DESCRIPTION
The previous URL resulted in a 404 'Not found'.

Link to what appears to be the new download page, found via Google.
